### PR TITLE
Propsed fix for #25

### DIFF
--- a/django_smg/frontend/static/frontend/songmakergallery_upload_template.csv
+++ b/django_smg/frontend/static/frontend/songmakergallery_upload_template.csv
@@ -1,4 +1,4 @@
-name,link
+﻿name,link
 Avery,https://musiclab.chromeexperiments.com/Song-Maker/song/4646052662607872
 Landon,https://musiclab.chromeexperiments.com/Song-Maker/song/5390246075170816
 Elizabeth,https://musiclab.chromeexperiments.com/Song-Maker/song/4914262951591936

--- a/ui_testing_data/bad_unicode_iso8859-1.csv
+++ b/ui_testing_data/bad_unicode_iso8859-1.csv
@@ -1,0 +1,4 @@
+name,link
+Günter,https://musiclab.chromeexperiments.com/Song-Maker/song/5245630969544704
+Patrick,https://musiclab.chromeexperiments.com/Song-Maker/song/5388216887672832
+Amélia,https://musiclab.chromeexperiments.com/Song-Maker/song/5388216887672832


### PR DESCRIPTION
So there are two things I did. One is I added the test data as you requested. The other is that I edited your upload template so that it begins with a byte-order-mark. This will increase the chances that if someone downloads the template, edits it on an older system (Notepad in Windows 7 maybe), the saved result will remain UTF-8 rather than one of the 8-bit ASCII flavors. I spot checked that the template-with-BOM loads fine in Windows 10 Notepad, Excel from Office 365 for Mac, and Numbers for Mac.

On really old systems that are not UTF-8 aware, the "name" label in the spreadsheet header could have what looks like junk characters at the beginning. These systems would give you problems with international characters anyway.

(Byte Order Mark (BOM) is a single Unicode character that does "nothing". It's defined as being zero-width, and doesn't glue adjacent characters together. There is a de facto practice of putting a byte order mark at the beginning of a file, because the resulting byte-sequence very clearly and unambiguously signifies that the file is UTF-8, UTF-16, or UTF-16LE.)
