### PR TITLE
filename typo fix in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ before you start so that you know where to put what!
 > The project's backend is a REST API built with the
 > [Django Rest Framework.](https://www.django-rest-framework.org/)
 
-1. Create the file `django_smg/django_smg/secrets_settings.py`.
+1. Create the file `django_smg/django_smg/secret_settings.py`.
 2. Define the `SECRET_KEY` variable in this file. Set it to any string your
    heart desires
 3. Set the environment variable `DJANGO_DEBUG` to any non-zero value


### PR DESCRIPTION
I believe there is a typo in contributing.md and specifically in the first point as shown in the screenshot below:

![image](https://user-images.githubusercontent.com/51930164/115446795-c6a49b00-a228-11eb-8518-4d6f0b72dce5.png)

`django_smg/django_smg/secrets_settings.py` should be `django_smg/django_smg/secret_settings.py`

I believe so since the `s` is omitted in the dev setup bashscript and the import in `django_smg/django_smg/settings.py`